### PR TITLE
feat(recipe): 레시피 상세 조리 순서(Steps) API 연동 및 UI 구현

### DIFF
--- a/Team_LJCO_back/src/main/java/com/korit/team_ljco/controller/RecipeController.java
+++ b/Team_LJCO_back/src/main/java/com/korit/team_ljco/controller/RecipeController.java
@@ -1,12 +1,10 @@
 package com.korit.team_ljco.controller;
 import com.korit.team_ljco.dto.RecipeCountRow;
 import com.korit.team_ljco.dto.RecipeListResponse;
+import com.korit.team_ljco.entity.RecipeStep;
 import com.korit.team_ljco.service.RecipeService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -42,6 +40,12 @@ public class RecipeController {
 
         // 서비스의 새로운 검색 메서드 호출
         return recipeService.searchRecipesByKeyword(page, userId, keyword);
+    }
+
+    // RecipeController.java 파일에 추가
+    @GetMapping("/{rcpId}/steps")
+    public List<RecipeStep> getRecipeSteps(@PathVariable Long rcpId) {
+        return recipeService.getRecipeSteps(rcpId); // 서비스 호출
     }
 
 }

--- a/Team_LJCO_back/src/main/java/com/korit/team_ljco/mapper/RecipeMapper.java
+++ b/Team_LJCO_back/src/main/java/com/korit/team_ljco/mapper/RecipeMapper.java
@@ -75,5 +75,6 @@ public interface RecipeMapper {
                                                     @Param("offset") int offset,
                                                     @Param("userId") int userId,
                                                     @Param("keyword") String keyword);
+   
 }
 

--- a/Team_LJCO_back/src/main/java/com/korit/team_ljco/service/RecipeService.java
+++ b/Team_LJCO_back/src/main/java/com/korit/team_ljco/service/RecipeService.java
@@ -242,4 +242,8 @@ public class RecipeService {
     public int getTotalRecipeCount() {
         return recipeMapper.countAllRecipes();
     }
+
+    public List<RecipeStep> getRecipeSteps(Long rcpId) {
+        return recipeMapper.selectRecipeSteps(rcpId);
+    }
 }

--- a/Team_LJCO_back/src/main/java/com/korit/team_ljco/service/UserServiceImpl.java
+++ b/Team_LJCO_back/src/main/java/com/korit/team_ljco/service/UserServiceImpl.java
@@ -1,5 +1,6 @@
 package com.korit.team_ljco.service;
 
+import com.korit.team_ljco.entity.RecipeStep;
 import com.korit.team_ljco.entity.User;
 import com.korit.team_ljco.jwt.JwtTokenProvider;
 import com.korit.team_ljco.mapper.UserMapper;
@@ -118,4 +119,6 @@ public class UserServiceImpl implements UserService {
     public List<User> searchUsers(Map<String, Object> params) {
         return userMapper.searchUsers(params);
     }
+    // RecipeServiceImpl.java 파일에 삭제
+
 }

--- a/Team_LJCO_front/src/components/recipeModal/RecipeSearchModal.jsx
+++ b/Team_LJCO_front/src/components/recipeModal/RecipeSearchModal.jsx
@@ -1,48 +1,57 @@
 /** @jsxImportSource @emotion/react */
 import { useState, useEffect } from "react";
 import axios from "axios";
-import { s } from "./styles";
+import { s } from "./styles"; // 스타일 파일 경로 확인 필수
 
-function RecipeDetailModal({ rcpId, rcpName, onClose }) {
+function RecipeSearchModal({ recipe, onClose }) {
     const [steps, setSteps] = useState([]);
     const [loading, setLoading] = useState(true);
 
     useEffect(() => {
-        const fetchSteps = async () => {
+        const fetchRecipeData = async () => {
+            if (!recipe?.rcpId) return;
+            setLoading(true);
             try {
-                // 💡 DB rcp_steps 테이블 조회 API (백엔드 구현 필요)
-                const res = await axios.get(`http://localhost:8080/api/recipes/${rcpId}/steps`);
-                setSteps(res.data); // [{stepNo: 1, stepDesc: "...", stepImgUrl: "..."}, ...]
+                // 백엔드 컨트롤러에 추가한 /api/recipes/{rcpId}/steps 호출
+                const stepRes = await axios.get(`http://localhost:8080/api/recipes/${recipe.rcpId}/steps`);
+                setSteps(stepRes.data);
             } catch (err) {
-                console.error("조리 과정 로드 실패", err);
+                console.error("데이터 로드 실패", err);
             } finally {
                 setLoading(false);
             }
         };
-        fetchSteps();
-    }, [rcpId]);
+        fetchRecipeData();
+    }, [recipe?.rcpId]);
 
     return (
         <div css={s.detailOverlay} onClick={onClose}>
             <div css={s.detailContent} onClick={(e) => e.stopPropagation()}>
                 <button className="back-btn" onClick={onClose}>← 검색 결과로 돌아가기</button>
-                <h2 style={{ marginBottom: '30px', fontSize: '22px' }}>{rcpName} 조리 순서</h2>
                 
+                {/* 레시피 기본 정보 */}
+                <h2 style={{ marginBottom: '10px', fontSize: '24px' }}>{recipe?.rcpName}</h2>
+                <div style={{ color: '#666', marginBottom: '30px' }}>난이도: {recipe?.level} | 조회수: {recipe?.rcpViewCount}</div>
+
                 {loading ? (
-                    <div style={{ textAlign: 'center', marginTop: '100px' }}>조리법을 읽어오는 중...</div>
+                    <div style={{ textAlign: 'center', padding: '50px' }}>정보를 불러오는 중...</div>
                 ) : (
-                    <div className="steps-list">
-                        {steps.map((step) => (
-                            <div key={step.stepNo} className="step-item">
-                                <div className="step-num">STEP {step.stepNo}</div>
-                                {step.stepImgUrl && (
-                                    <div className="step-img">
-                                        <img src={step.stepImgUrl} alt="" />
-                                    </div>
-                                )}
-                                <div className="step-desc">{step.stepDesc}</div>
-                            </div>
-                        ))}
+                    <div className="content-scroll">
+                        {/* 조리 순서 렌더링 */}
+                        <h3 style={{ borderBottom: '2px solid #eee', paddingBottom: '10px' }}>조리 순서</h3>
+                        <div className="steps-list">
+                            {steps.length > 0 ? steps.map((step) => (
+                                <div key={step.stepId} className="step-item" style={{ marginBottom: '20px' }}>
+                                    <div className="step-num" style={{ fontWeight: 'bold', color: '#ff7043' }}>STEP {step.stepNo}</div>
+                                    <div className="step-desc">{step.stepDesc}</div>
+                                    {step.stepImgUrl && (
+                                        <div className="step-img" style={{ marginTop: '10px' }}>
+                                            <img src={step.stepImgUrl} alt={`Step ${step.stepNo}`} style={{ maxWidth: '100%', borderRadius: '8px' }} />
+                                        </div>
+                                    )}
+                                </div>
+                            )) : <div>등록된 조리 순서가 없습니다.</div>}
+                        </div>
                     </div>
                 )}
             </div>
@@ -50,4 +59,4 @@ function RecipeDetailModal({ rcpId, rcpName, onClose }) {
     );
 }
 
-export default RecipeDetailModal;
+export default RecipeSearchModal;

--- a/Team_LJCO_front/src/pages/Recipe/Recipe.jsx
+++ b/Team_LJCO_front/src/pages/Recipe/Recipe.jsx
@@ -36,33 +36,50 @@ function Recipe() {
     }, [loading, hasMore]);
 
     // 💡 데이터 페칭 로직 수정
-   useEffect(() => {
-        const params = new URLSearchParams(location.search);
-        const keywordParam = params.get("keyword");
+   // Recipe.jsx 내부의 useEffect를 이 내용으로 교체하세요.
+useEffect(() => {
+    const params = new URLSearchParams(location.search);
+    const keywordParam = params.get("keyword");
+    
+    const fetchRecipes = async () => {
+        setLoading(true);
+        const token = localStorage.getItem("accessToken");
         
-        if (keywordParam) {
-            setRecipeSearchTerm(keywordParam); // 검색창에 글자 넣기
+        try {
+            // 💡 검색어가 있으면 search API, 없으면 기본 목록 API 호출
+            const url = keywordParam 
+                ? `http://localhost:8080/api/recipes/search` 
+                : `http://localhost:8080/api/recipes`;
+
+            const res = await axios.get(url, {
+                // 💡 검색어가 없을 때는 keyword를 보내지 않도록 설정
+                params: { 
+                    page: page, 
+                    userId: 0, 
+                    keyword: keywordParam || undefined 
+                },
+                headers: { Authorization: `Bearer ${token}` }
+            });
             
-            // 💡 자동으로 검색 API 호출 로직 실행
-            const fetchFromUrl = async () => {
-                setLoading(true);
-                const token = localStorage.getItem("accessToken");
-                try {
-                    const res = await axios.get(`http://localhost:8080/api/recipes/search`, {
-                        params: { page: 1, userId: 0, keyword: keywordParam },
-                        headers: { Authorization: `Bearer ${token}` }
-                    });
-                    setRecipes(res.data); // 결과 뿌리기
-                    setHasMore(false);    // 추가 로딩 차단
-                } catch (err) {
-                    console.error("URL 검색 로드 실패:", err);
-                } finally {
-                    setLoading(false);
-                }
-            };
-            fetchFromUrl();
+            // 💡 페이지가 1이면(검색이나 첫 진입) 리스트를 새로 만들고, 
+            // 💡 페이지가 2 이상(무한 스크롤)이면 기존 리스트에 추가합니다.
+            setRecipes(prev => page === 1 ? res.data : [...prev, ...res.data]);
+            
+            // 데이터가 10개 미만이면 더 이상 가져올 데이터가 없다고 판단
+            if (res.data.length < 10) setHasMore(false);
+            
+            // 입력창에 현재 검색어 표시 (없으면 빈 칸)
+            if (keywordParam) setRecipeSearchTerm(keywordParam);
+
+        } catch (err) {
+            console.error("데이터 로딩 실패:", err);
+        } finally {
+            setLoading(false);
         }
-    }, [location.search]); // 💡 페이지가 바뀔 때마다 실행
+    };
+
+    fetchRecipes();
+}, [page, location.search]); // ✅ 페이지 번호나 주소(검색어)가 바뀔 때마다 실행
 
     const handleRecipeSearch = async () => {
     if (!recipeSearchTerm.trim()) return;


### PR DESCRIPTION
1. Backend & Database
Controller: 레시피 ID 기반 조리 단계 조회를 위한 /api/recipes/{rcpId}/steps 엔드포인트 추가

Service: Mapper를 호출하여 RecipeStep 리스트를 반환하는 비즈니스 로직 구현

Mapper: rcp_step 테이블에서 조리 순서 데이터를 조회하는 SQL 쿼리 작성

2. Frontend (React)
Recipe.jsx:

useEffect를 통합하여 URL 파라미터(keyword) 변화에 따른 조건부 데이터 페칭 최적화

무한 스크롤 연동 및 페이지 번호 관리 로직 개선

RecipeSearchModal.jsx:

모달 오픈 시 해당 레시피의 조리 단계 데이터를 API로 호출

steps 배열을 활용해 STEP별 이미지와 설명이 포함된 조리 순서 UI 렌더링