### PR TITLE
feat(recipe): 레시피-냉장고 데이터 대조 및 신선도 기반 UI 구현

### DIFF
--- a/Team_LJCO_back/src/main/java/com/korit/team_ljco/controller/RecipeController.java
+++ b/Team_LJCO_back/src/main/java/com/korit/team_ljco/controller/RecipeController.java
@@ -18,16 +18,15 @@ public class RecipeController {
     @GetMapping
     public List<RecipeListResponse> getAllRecipes(
             @RequestParam(defaultValue = "1") int page,
-            // required = false를 추가하여 userId가 없어도 요청을 허용합니다.
-            @RequestParam(required = false, defaultValue = "0") int userId) {
+            // int -> Long으로 변경하여 더 큰 범위를 수용하고 DB 타입과 맞춥니다.
+            @RequestParam(required = false, defaultValue = "0") Long userId) {
 
-        List<RecipeListResponse> recipeListSelect = recipeService.findRecipes(page, userId);
-        return recipeListSelect;
+        return recipeService.findRecipes(page, userId);
     }
 
     @GetMapping("/MatchRate")
     public List<RecipeCountRow> getMatchRate(
-            @RequestParam(required = false, defaultValue = "0") int userId,
+            @RequestParam(required = false, defaultValue = "0") Long userId,
             @RequestParam List<Integer> rcpIds) {
         return recipeService.findMateRate(userId, rcpIds);
     }
@@ -35,10 +34,9 @@ public class RecipeController {
     @GetMapping("/search")
     public List<RecipeListResponse> searchRecipes(
             @RequestParam(defaultValue = "1") int page,
-            @RequestParam int userId,
-            @RequestParam String keyword) { // 프론트에서 넘어올 검색어
+            @RequestParam Long userId, // 여기도 Long으로 변경
+            @RequestParam String keyword) {
 
-        // 서비스의 새로운 검색 메서드 호출
         return recipeService.searchRecipesByKeyword(page, userId, keyword);
     }
 

--- a/Team_LJCO_back/src/main/java/com/korit/team_ljco/entity/RecipeIngredient.java
+++ b/Team_LJCO_back/src/main/java/com/korit/team_ljco/entity/RecipeIngredient.java
@@ -18,6 +18,8 @@ public class RecipeIngredient {
     private String rcpIngAmt;
     private Integer rcpIngOrd;
     private LocalDateTime createdAt;
+    private Integer dDay;   // 💡 MyBatis의 d_day와 매핑
+    private boolean hasIng; // 💡 MyBatis의 has_ing와 매핑 (1이면 true, 0이면 false)
 
     // 재료 정보 (JOIN용)
     private Ingredient ingredient;

--- a/Team_LJCO_back/src/main/java/com/korit/team_ljco/mapper/RecipeMapper.java
+++ b/Team_LJCO_back/src/main/java/com/korit/team_ljco/mapper/RecipeMapper.java
@@ -18,11 +18,11 @@ public interface RecipeMapper {
     //페이지 넘김을 고려한 pagesize 생성 => 서비스에서 계산함
     List<RecipeListResponse> getRecipes(@Param("pageSize") int pageSize,
                                         @Param("offset") int offset,
-                                        @Param("userId") int userId);
+                                        @Param("userId") Long userId);
 
     //일치율
     //한 사람에 대한 레시피라서 userid는 하나 rcpids는 여러개라 리스트
-    List<RecipeCount> getMatchRate(@Param("userId") int userId,
+    List<RecipeCount> getMatchRate(@Param("userId") Long userId,
                                     @Param("rcpIds") List<Integer> rcpIds);
 
     //며칠남았는지
@@ -73,8 +73,8 @@ public interface RecipeMapper {
     // 검색 결과를 RecipeListResponse DTO 리스트로 반환하도록 정의
     List<RecipeListResponse> searchRecipesByKeyword(@Param("pageSize") int pageSize,
                                                     @Param("offset") int offset,
-                                                    @Param("userId") int userId,
+                                                    @Param("userId") Long userId,
                                                     @Param("keyword") String keyword);
-   
+
 }
 

--- a/Team_LJCO_back/src/main/java/com/korit/team_ljco/service/RecipeService.java
+++ b/Team_LJCO_back/src/main/java/com/korit/team_ljco/service/RecipeService.java
@@ -36,7 +36,7 @@ public class RecipeService {
     }
 
     //전체 레시피 조회
-    public List<RecipeListResponse> findRecipes(int page, int userId) {
+    public List<RecipeListResponse> findRecipes(int page, Long userId) {
         int pageSize = 10;
         int offset = (page - 1) * pageSize;
 
@@ -45,14 +45,14 @@ public class RecipeService {
     }
 
     // 검색 기능을 위한 메서드 추가
-    public List<RecipeListResponse> searchRecipesByKeyword(int page, int userId, String keyword) {
+    public List<RecipeListResponse> searchRecipesByKeyword(int page, Long userId, String keyword) {
         int pageSize = 10;
         int offset = (page - 1) * pageSize;
 
         // 우리가 Mapper에 새로 만든 메서드를 호출합니다.
         return recipeMapper.searchRecipesByKeyword(pageSize, offset, userId, keyword);
     }
-    public List<RecipeCountRow> findMateRate(int userId, List<Integer> rcpIds) {
+    public List<RecipeCountRow> findMateRate(Long userId, List<Integer> rcpIds) {
         List<RecipeCount> countAll =  recipeMapper.getMatchRate(userId,rcpIds);
         List<RecipeCountRow> recipeRowsList = new ArrayList<>();
         //내 재료 겹치는 개수, 재료 레시피 개수 구하기

--- a/Team_LJCO_back/src/main/resources/mapper/RecipeMapper.xml
+++ b/Team_LJCO_back/src/main/resources/mapper/RecipeMapper.xml
@@ -26,6 +26,9 @@
         <result property="createdAt" column="created_at"/>
         <result property="ingName" column="ing_name"/>
         <result property="ingImgUrl" column="ing_img_url"/>
+
+        <result property="dDay" column="d_day"/>
+        <result property="hasIng" column="has_ing"/>
     </resultMap>
 
     <!-- RecipeStep ResultMap 추가 (누락되어 있었음!) -->
@@ -261,30 +264,22 @@
     </select>
     <select id="searchRecipesByKeyword" resultMap="RecipeListWithIngredientsMap">
         SELECT
-        r.rcp_id,
-        r.rcp_name,
-        r.rcp_img_url,
-        r.rcp_view_count,
-        r.level,
-        i.ing_id,
-        i.ing_name
+        r.rcp_id, r.rcp_name, r.rcp_img_url, r.rcp_view_count, r.level,
+        i.ing_id, i.ing_name,
+        /* 💡 추가된 부분: 사용자의 냉장고와 대조하여 D-Day 계산 */
+        DATEDIFF(CURRENT_TIMESTAMP, ui.created_at) AS d_day,
+        CASE WHEN ui.user_ing_id IS NOT NULL THEN 1 ELSE 0 END AS has_ing
         FROM (
-        /* 1. 검색 조건에 맞는 레시피 ID들을 먼저 뽑습니다. */
         SELECT rcp_id, rcp_name, rcp_img_url, rcp_view_count, level
         FROM rcp
         WHERE rcp_name LIKE CONCAT('%', #{keyword}, '%')
-        ORDER BY
-        CASE
-        WHEN rcp_name = #{keyword} THEN 1
-        WHEN rcp_name LIKE CONCAT(#{keyword}, '%') THEN 2
-        ELSE 3
-        END,
-        rcp_id DESC
+        ORDER BY rcp_id DESC
         LIMIT #{pageSize} OFFSET #{offset}
         ) r
-        /* 2. 뽑힌 레시피들에 대해 재료 정보를 합칩니다. (이게 있어야 화면에 재료가 뜹니다) */
         LEFT JOIN rcp_ing ri ON r.rcp_id = ri.rcp_id
         LEFT JOIN ingredients i ON ri.ing_id = i.ing_id
+        /* 💡 사용자의 냉장고 재료와 조인 */
+        LEFT JOIN user_ingredients ui ON i.ing_id = ui.ing_id AND ui.user_id = #{userId}
         ORDER BY r.rcp_id DESC
     </select>
 </mapper>

--- a/Team_LJCO_front/src/components/recipeModal/RecipeSearchModal.jsx
+++ b/Team_LJCO_front/src/components/recipeModal/RecipeSearchModal.jsx
@@ -1,7 +1,8 @@
 /** @jsxImportSource @emotion/react */
 import { useState, useEffect } from "react";
 import axios from "axios";
-import { s } from "./styles"; // 스타일 파일 경로 확인 필수
+import { s } from "./styles";
+import { getColorByDay } from "../../utils/colorUtils";
 
 function RecipeSearchModal({ recipe, onClose }) {
     const [steps, setSteps] = useState([]);
@@ -12,7 +13,6 @@ function RecipeSearchModal({ recipe, onClose }) {
             if (!recipe?.rcpId) return;
             setLoading(true);
             try {
-                // 백엔드 컨트롤러에 추가한 /api/recipes/{rcpId}/steps 호출
                 const stepRes = await axios.get(`http://localhost:8080/api/recipes/${recipe.rcpId}/steps`);
                 setSteps(stepRes.data);
             } catch (err) {
@@ -29,29 +29,72 @@ function RecipeSearchModal({ recipe, onClose }) {
             <div css={s.detailContent} onClick={(e) => e.stopPropagation()}>
                 <button className="back-btn" onClick={onClose}>← 검색 결과로 돌아가기</button>
                 
-                {/* 레시피 기본 정보 */}
-                <h2 style={{ marginBottom: '10px', fontSize: '24px' }}>{recipe?.rcpName}</h2>
-                <div style={{ color: '#666', marginBottom: '30px' }}>난이도: {recipe?.level} | 조회수: {recipe?.rcpViewCount}</div>
+                {/* 1. Header: 이름 및 정보 */}
+                <div style={{ marginBottom: '20px' }}>
+                    <h2 style={{ fontSize: '28px', fontWeight: '900', marginBottom: '8px' }}>{recipe?.rcpName}</h2>
+                    <div style={{ display: 'flex', gap: '15px', color: '#ff7043', fontWeight: '700', fontSize: '14px' }}>
+                        <span>🔥 {recipe?.level === 1 ? '쉬움' : '보통'}</span>
+                        <span>👁️ {recipe?.rcpViewCount?.toLocaleString()}</span>
+                    </div>
+                </div>
 
+                {/* 2. 통합 정보 박스 (Visual + Info + Ingredients) */}
+                <div style={{ background: '#f8f8f8', borderRadius: '30px', padding: '25px', marginBottom: '35px' }}>
+                    <div style={{ width: '100%', height: '250px', borderRadius: '20px', overflow: 'hidden', marginBottom: '20px' }}>
+                        <img src={recipe?.rcpImgUrl} alt="main" style={{ width: '100%', height: '100%', objectFit: 'cover' }} />
+                    </div>
+                    <div style={{ display: 'flex', justifyContent: 'center', gap: '30px', marginBottom: '20px', fontSize: '14px', color: '#666', fontWeight: '600' }}>
+                        <span>⏱️ 15분</span>
+                        <span>👥 2인분</span>
+                        <span>📂 메인요리</span>
+                    </div>
+                    <hr style={{ border: '0', borderTop: '1px solid #e0e0e0', marginBottom: '20px' }} />
+                    <h3 style={{ fontSize: '15px', fontWeight: '800', marginBottom: '12px', color: '#555' }}>필요한 재료</h3>
+                    {/* Ingredients (신선도 색상 적용) */}
+                    <div style={{ display: 'flex', flexWrap: 'wrap', gap: '8px' }}>
+                        {recipe.ingredients?.map((ing, idx) => {
+                            // 💡 대소문자 및 언더바 이슈 방지를 위해 모두 체크
+                            const hasIngredient = ing.hasIng === true || ing.hasIng === 1 || ing.has_ing === 1;
+                            const dDayValue = (ing.dDay !== undefined && ing.dDay !== null) ? ing.dDay : ing.dday;
+
+                            const bgColor = hasIngredient ? getColorByDay(dDayValue) : "#F0F0F0";
+                            // ⚠️ 아래 color와 border 부분에서 hasIng를 hasIngredient로 수정했습니다!
+                            const textColor = hasIngredient ? "#000" : "#999";
+
+                            return (
+                                <span key={idx} style={{
+                                    backgroundColor: bgColor,
+                                    color: textColor, // 💡 수정완료
+                                    padding: '7px 14px', 
+                                    borderRadius: '12px', 
+                                    fontSize: '13px', 
+                                    fontWeight: '700',
+                                    border: hasIngredient ? 'none' : '1px solid #e0e0e0' // 💡 수정완료
+                                }}>
+                                    {ing.ingName} {ing.rcpIngAmt && `(${ing.rcpIngAmt})`}
+                                </span>
+                            );
+                        })}
+                    </div>
+                </div>
+
+                {/* 3. 고도화된 조리 순서 섹션 */}
+                <h3 style={{ fontSize: '20px', fontWeight: '900', marginBottom: '25px' }}>🍳 조리 순서</h3>
                 {loading ? (
-                    <div style={{ textAlign: 'center', padding: '50px' }}>정보를 불러오는 중...</div>
+                    <div style={{ textAlign: 'center', padding: '30px' }}>로딩 중...</div>
                 ) : (
-                    <div className="content-scroll">
-                        {/* 조리 순서 렌더링 */}
-                        <h3 style={{ borderBottom: '2px solid #eee', paddingBottom: '10px' }}>조리 순서</h3>
-                        <div className="steps-list">
-                            {steps.length > 0 ? steps.map((step) => (
-                                <div key={step.stepId} className="step-item" style={{ marginBottom: '20px' }}>
-                                    <div className="step-num" style={{ fontWeight: 'bold', color: '#ff7043' }}>STEP {step.stepNo}</div>
-                                    <div className="step-desc">{step.stepDesc}</div>
-                                    {step.stepImgUrl && (
-                                        <div className="step-img" style={{ marginTop: '10px' }}>
-                                            <img src={step.stepImgUrl} alt={`Step ${step.stepNo}`} style={{ maxWidth: '100%', borderRadius: '8px' }} />
-                                        </div>
-                                    )}
-                                </div>
-                            )) : <div>등록된 조리 순서가 없습니다.</div>}
-                        </div>
+                    <div className="steps-list" style={{ display: 'flex', flexDirection: 'column', gap: '40px' }}>
+                        {steps.map((step) => (
+                            <div key={step.stepId} className="step-item">
+                                <div style={{ fontSize: '13px', fontWeight: '900', color: '#ff7043', marginBottom: '8px' }}>STEP {step.stepNo}</div>
+                                <p style={{ fontSize: '16px', lineHeight: '1.7', color: '#444', marginBottom: '15px' }}>{step.stepDesc}</p>
+                                {step.stepImgUrl && (
+                                    <div style={{ borderRadius: '20px', overflow: 'hidden', boxShadow: '0 4px 15px rgba(0,0,0,0.1)' }}>
+                                        <img src={step.stepImgUrl} alt="step" style={{ width: '100%' }} />
+                                    </div>
+                                )}
+                            </div>
+                        ))}
                     </div>
                 )}
             </div>

--- a/Team_LJCO_front/src/utils/colorUtils.js
+++ b/Team_LJCO_front/src/utils/colorUtils.js
@@ -1,0 +1,10 @@
+// 💡 민석님이 제공해주신 색상 로직을 공통 함수로 분리
+export const getColorByDay = (day) => {
+    if (day === null || day === undefined) return "#DBDBDB"; // 재료가 없는 경우 (회색)
+    
+    if (day <= 3) return "#34C759";  // D+0 ~ D+3: 매우 신선
+    if (day <= 7) return "#FFD60A";  // D+4 ~ D+7: 사용 권장
+    if (day <= 14) return "#FF9F0A"; // D+8 ~ D+14: 주의
+    if (day <= 29) return "#FF3B30"; // D+15 ~ D+29: 위험
+    return "#DBDBDB";                // D+30 이상: 폐기 권장
+};


### PR DESCRIPTION
백엔드: 데이터 대조용 API 고도화
* [ ] 사용자 냉장고 데이터 JOIN: 레시피 조회 시, 현재 사용자가 가진 재료(user_ingredients) 정보와 대조하여 '보유 여부' 및 '유통기한 기반 D-Day' 값을 함께 반환하도록 SQL 수정.
* [ ] D-Day 계산 로직: DB의 등록일 혹은 유통기한을 기준으로 오늘 날짜와의 차이를 계산하여 반환하는 로직 추가.

프론트엔드: 공통 신선도 로직 모듈화
* [ ] getColorByDay 유틸리티 함수 생성: 두 번째 캡쳐본의 색상 로직을 src/utils 등에 공통 함수로 분리하여 냉장고 페이지와 레시피 페이지에서 동시 사용.
* [ ] 재료 칩(Ingredient Chip) 컴포넌트 구현: 재료명과 D-Day 색상을 입힌 공통 UI 컴포넌트 제작.

레시피 목록 및 모달 UI 적용
* [ ] 레시피 카드(Recipe.jsx) 적용: 하단 '필요한 재료' 섹션에 냉장고 보유 재료는 해당 색상(초록/노랑/주황 등)을 입히고, 없는 재료는 회색(무채색)으로 표시.
* [ ] 상세 모달(RecipeSearchModal.jsx) 적용: 모달 내 재료 리스트에도 동일한 색상 시스템 적용 및 계량 정보(rcp_ing_amt) 노출.
* [ ] 조리 순서 섹션 고도화: 말씀하신 대로 단계별 이미지와 설명을 더 깔끔하게 배치.