### PR TITLE
feat(recipe): 레시피 리스트/모달 UI 개선 및 정렬·페이지네이션 스타일 수정

### DIFF
--- a/Team_LJCO_front/src/components/common/Pagination/index.jsx
+++ b/Team_LJCO_front/src/components/common/Pagination/index.jsx
@@ -1,53 +1,123 @@
+/** @jsxImportSource @emotion/react */
+import { css } from "@emotion/react";
 
-function Pagination({page, totalPages, onChange}) {
+// 스타일 정의
+const s = {
+    container: css`
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        gap: 8px;
+        margin-top: 40px;
+        margin-bottom: 60px;
+    `,
+    pageBtn: (isActive) => css`
+        min-width: 36px;
+        height: 36px;
+        padding: 0 6px;
+        border-radius: 50%; /* 둥근 버튼 */
+        border: none;
+        background-color: ${isActive ? "#FF7043" : "transparent"};
+        color: ${isActive ? "#FFFFFF" : "#555555"};
+        font-size: 14px;
+        font-weight: 700;
+        cursor: pointer;
+        transition: all 0.2s;
+
+        &:hover {
+            background-color: ${isActive ? "#FF7043" : "#F0F0F0"};
+        }
+        &:disabled {
+            cursor: default;
+            color: #bbb;
+            &:hover { background-color: transparent; }
+        }
+    `,
+    navBtn: css`
+        padding: 8px 16px;
+        border-radius: 20px;
+        border: 1px solid #E0E0E0;
+        background-color: white;
+        color: #555;
+        font-size: 13px;
+        font-weight: 600;
+        cursor: pointer;
+        transition: all 0.2s;
+
+        &:hover:not(:disabled) {
+            border-color: #FF7043;
+            color: #FF7043;
+            background-color: #FFF3E0;
+        }
+        &:disabled {
+            background-color: #F9F9F9;
+            color: #CCC;
+            cursor: not-allowed;
+            border-color: #EEE;
+        }
+    `
+};
+
+function Pagination({ page, totalPages, onChange }) {
     const totalPageCount = 10;
     const pages = [];
 
-
     const groupIndex = Math.floor((page - 1) / totalPageCount);
     const startPage = groupIndex * totalPageCount + 1;
-    const endPage = Math.min(startPage +  totalPageCount -1 ,totalPages);
+    const endPage = Math.min(startPage + totalPageCount - 1, totalPages);
 
-        for (let i = startPage; i <= endPage; i++) {
+    for (let i = startPage; i <= endPage; i++) {
         pages.push(i);
     }
+
     const onClickFirstPageButton = () => {
-
-
-        if(page === 1) {
+        if (page === 1) {
             alert("첫페이지입니다");
             return;
         }
-        onChange(startPage - 1);
+        // 이전 그룹의 마지막 페이지로 이동하는 로직 유지
+        onChange(Math.max(1, startPage - 1));
     };
-        const onClickLastPageButton = () => {
-        if(page === totalPages) {
+
+    const onClickLastPageButton = () => {
+        if (page === totalPages) {
             alert("마지막 페이지입니다");
             return;
         }
-        onChange(endPage + 1);
+        // 다음 그룹의 첫 페이지로 이동하는 로직 유지
+        onChange(Math.min(totalPages, endPage + 1));
     };
+
     return (
-        <div>
-            <button onClick={onClickFirstPageButton} disabled={startPage == totalPages}>
+        <div css={s.container}>
+            <button 
+                css={s.navBtn} 
+                onClick={onClickFirstPageButton} 
+                disabled={page === 1} // 로직 수정: 1페이지면 비활성화가 더 자연스러움
+            >
                 이전
             </button>
+            
             {pages.map((p) => (
                 <button
-                key={p}
-                onClick={() => onChange(p)}
-                disabled={p === page}
+                    key={p}
+                    css={s.pageBtn(p === page)}
+                    onClick={() => onChange(p)}
+                    disabled={p === page}
                 >
                     {p}
                 </button>
-            ))
-                
-            }
-            <button onClick={onClickLastPageButton} disabled={endPage == totalPages}>
+            ))}
+
+            <button 
+                css={s.navBtn} 
+                onClick={onClickLastPageButton} 
+                disabled={page === totalPages} // 로직 수정: 마지막 페이지면 비활성화
+            >
                 다음
             </button>
         </div>
     );
-
 }
+
 export default Pagination;

--- a/Team_LJCO_front/src/components/recipeModal/RecipeSearchModal.jsx
+++ b/Team_LJCO_front/src/components/recipeModal/RecipeSearchModal.jsx
@@ -8,6 +8,22 @@ function RecipeSearchModal({ recipe, onClose }) {
     const [steps, setSteps] = useState([]);
     const [loading, setLoading] = useState(true);
 
+    // 매치율 텍스트 로직
+    const matchRate = Number(recipe?.matchRate ?? 0);
+    
+    const getMatchRateText = (rate) => {
+        if (rate <= 0) return '재료를 구매하셔야 해요!';
+        if (rate < 50) return '조금만 더 있으면 돼요';
+        if (rate < 70) return '거의 만들 수 있어요';
+        return '지금 바로 도전 가능!';
+    };
+
+    // 💡 추가: 매치율 아이콘 로직 (일관성을 위해 아이콘 추가)
+    const getMatchIcon = (rate) => {
+        if (rate < 70) return '🛒'; // 재료 부족할 땐 장바구니
+        return '🍳'; // 요리 가능할 땐 프라이팬
+    };
+
     useEffect(() => {
         const fetchRecipeData = async () => {
             if (!recipe?.rcpId) return;
@@ -31,45 +47,63 @@ function RecipeSearchModal({ recipe, onClose }) {
                 
                 {/* 1. Header: 이름 및 정보 */}
                 <div style={{ marginBottom: '20px' }}>
-                    <h2 style={{ fontSize: '28px', fontWeight: '900', marginBottom: '8px' }}>{recipe?.rcpName}</h2>
-                    <div style={{ display: 'flex', gap: '15px', color: '#ff7043', fontWeight: '700', fontSize: '14px' }}>
-                        <span>🔥 {recipe?.level === 1 ? '쉬움' : '보통'}</span>
-                        <span>👁️ {recipe?.rcpViewCount?.toLocaleString()}</span>
+                    <h2 style={{ fontSize: '28px', fontWeight: '900', marginBottom: '12px' }}>{recipe?.rcpName}</h2>
+                    
+                    {/* 정보 그리드 */}
+                    <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+                        
+                        {/* 왼쪽: 난이도 & 조회수 */}
+                        <div style={{ display: 'flex', gap: '15px', color: '#ff7043', fontWeight: '700', fontSize: '15px' }}>
+                            <span style={{ display: 'flex', alignItems: 'center', gap: '4px' }}>
+                                🔥 {recipe?.level === 1 ? '쉬움' : recipe?.level === 2 ? '보통' : '어려움'}
+                            </span>
+                            <span style={{ display: 'flex', alignItems: 'center', gap: '4px' }}>
+                                👁️ {recipe?.rcpViewCount?.toLocaleString()}
+                            </span>
+                        </div>
+
+                        {/* 오른쪽: 매치율 (박스 제거 -> 아이콘+텍스트 형태) */}
+                        <div style={{ 
+                            display: 'flex',
+                            alignItems: 'center',
+                            gap: '4px', // 아이콘과 텍스트 사이 간격
+                            color: '#FF7043', 
+                            fontWeight: '800', 
+                            fontSize: '15px' // 왼쪽 폰트 사이즈와 통일
+                        }}>
+                            {/* 상황에 맞는 아이콘 + 텍스트 */}
+                            <span>{getMatchIcon(matchRate)}</span>
+                            <span>{getMatchRateText(matchRate)} ({matchRate}%)</span>
+                        </div>
                     </div>
                 </div>
 
-                {/* 2. 통합 정보 박스 (Visual + Info + Ingredients) */}
+                {/* 2. 이미지 & 재료 섹션 */}
                 <div style={{ background: '#f8f8f8', borderRadius: '30px', padding: '25px', marginBottom: '35px' }}>
-                    <div style={{ width: '100%', height: '250px', borderRadius: '20px', overflow: 'hidden', marginBottom: '20px' }}>
+                    <div style={{ width: '100%', height: '300px', borderRadius: '20px', overflow: 'hidden', marginBottom: '25px' }}>
                         <img src={recipe?.rcpImgUrl} alt="main" style={{ width: '100%', height: '100%', objectFit: 'cover' }} />
                     </div>
-                    <div style={{ display: 'flex', justifyContent: 'center', gap: '30px', marginBottom: '20px', fontSize: '14px', color: '#666', fontWeight: '600' }}>
-                        <span>⏱️ 15분</span>
-                        <span>👥 2인분</span>
-                        <span>📂 메인요리</span>
-                    </div>
-                    <hr style={{ border: '0', borderTop: '1px solid #e0e0e0', marginBottom: '20px' }} />
-                    <h3 style={{ fontSize: '15px', fontWeight: '800', marginBottom: '12px', color: '#555' }}>필요한 재료</h3>
-                    {/* Ingredients (신선도 색상 적용) */}
+
+                    <h3 style={{ fontSize: '16px', fontWeight: '800', marginBottom: '12px', color: '#555' }}>필요한 재료</h3>
+                    
                     <div style={{ display: 'flex', flexWrap: 'wrap', gap: '8px' }}>
                         {recipe.ingredients?.map((ing, idx) => {
-                            // 💡 대소문자 및 언더바 이슈 방지를 위해 모두 체크
                             const hasIngredient = ing.hasIng === true || ing.hasIng === 1 || ing.has_ing === 1;
                             const dDayValue = (ing.dDay !== undefined && ing.dDay !== null) ? ing.dDay : ing.dday;
 
-                            const bgColor = hasIngredient ? getColorByDay(dDayValue) : "#F0F0F0";
-                            // ⚠️ 아래 color와 border 부분에서 hasIng를 hasIngredient로 수정했습니다!
+                            const bgColor = hasIngredient ? getColorByDay(dDayValue) : "#FFFFFF";
                             const textColor = hasIngredient ? "#000" : "#999";
 
                             return (
                                 <span key={idx} style={{
                                     backgroundColor: bgColor,
-                                    color: textColor, // 💡 수정완료
-                                    padding: '7px 14px', 
+                                    color: textColor,
+                                    padding: '8px 16px', 
                                     borderRadius: '12px', 
-                                    fontSize: '13px', 
-                                    fontWeight: '700',
-                                    border: hasIngredient ? 'none' : '1px solid #e0e0e0' // 💡 수정완료
+                                    fontSize: '14px', 
+                                    fontWeight: '600',
+                                    border: hasIngredient ? 'none' : '1px solid #ddd',
+                                    boxShadow: hasIngredient ? '0 2px 5px rgba(0,0,0,0.05)' : 'none'
                                 }}>
                                     {ing.ingName} {ing.rcpIngAmt && `(${ing.rcpIngAmt})`}
                                 </span>
@@ -78,21 +112,21 @@ function RecipeSearchModal({ recipe, onClose }) {
                     </div>
                 </div>
 
-                {/* 3. 고도화된 조리 순서 섹션 */}
-                <h3 style={{ fontSize: '20px', fontWeight: '900', marginBottom: '25px' }}>🍳 조리 순서</h3>
+                {/* 3. 조리 순서 섹션 */}
+                <h3 style={{ fontSize: '22px', fontWeight: '900', marginBottom: '25px' }}>🍳 조리 순서</h3>
                 {loading ? (
-                    <div style={{ textAlign: 'center', padding: '30px' }}>로딩 중...</div>
+                    <div style={{ textAlign: 'center', padding: '30px', color: '#888' }}>레시피 정보를 불러오는 중입니다...</div>
                 ) : (
                     <div className="steps-list" style={{ display: 'flex', flexDirection: 'column', gap: '40px' }}>
                         {steps.map((step) => (
                             <div key={step.stepId} className="step-item">
-                                <div style={{ fontSize: '13px', fontWeight: '900', color: '#ff7043', marginBottom: '8px' }}>STEP {step.stepNo}</div>
-                                <p style={{ fontSize: '16px', lineHeight: '1.7', color: '#444', marginBottom: '15px' }}>{step.stepDesc}</p>
+                                <div style={{ fontSize: '14px', fontWeight: '900', color: '#ff7043', marginBottom: '10px' }}>STEP {step.stepNo}</div>
                                 {step.stepImgUrl && (
-                                    <div style={{ borderRadius: '20px', overflow: 'hidden', boxShadow: '0 4px 15px rgba(0,0,0,0.1)' }}>
-                                        <img src={step.stepImgUrl} alt="step" style={{ width: '100%' }} />
+                                    <div style={{ borderRadius: '20px', overflow: 'hidden', boxShadow: '0 4px 15px rgba(0,0,0,0.08)', marginBottom: '15px' }}>
+                                        <img src={step.stepImgUrl} alt="step" style={{ width: '100%', display: 'block' }} />
                                     </div>
                                 )}
+                                <p style={{ fontSize: '16px', lineHeight: '1.7', color: '#333', wordBreak: 'keep-all' }}>{step.stepDesc}</p>
                             </div>
                         ))}
                     </div>

--- a/Team_LJCO_front/src/components/recipeModal/styles.js
+++ b/Team_LJCO_front/src/components/recipeModal/styles.js
@@ -2,45 +2,44 @@
 import { css } from "@emotion/react";
 
 export const s = {
+    // 기존 스타일 유지... (modalOverlay, grid, recipeCard 등)
     modalOverlay: css`
         position: fixed; top: 0; left: 0; width: 100%; height: 100%;
         background: rgba(0, 0, 0, 0.5); display: flex; justify-content: center; align-items: center; z-index: 2000;
         backdrop-filter: blur(4px);
     `,
-    modalContent: css`
+    modalContent: css` /* 이건 재료 추가 모달용인듯 하여 건드리지 않음 */
         background: white; border-radius: 40px; width: 90%; max-width: 900px; max-height: 85vh;
         padding: 40px; overflow-y: auto; box-shadow: 0 20px 60px rgba(0, 0, 0, 0.15); position: relative;
-        .header { display: flex; justify-content: space-between; align-items: center; margin-bottom: 30px; 
-            h2 { font-size: 24px; font-weight: 800; color: #333; }
-        }
     `,
-    grid: css`
-        display: grid; grid-template-columns: repeat(auto-fill, minmax(240px, 1fr)); gap: 25px;
-    `,
-    recipeCard: css`
-        background: #FFFFFF; border: 1px solid #f0f0f0; border-radius: 25px; padding: 20px;
-        transition: 0.3s; cursor: pointer;
-        &:hover { transform: translateY(-5px); box-shadow: 0 10px 25px rgba(255, 112, 67, 0.1); }
-        .img-box { width: 100%; height: 150px; background: #f9f9f9; border-radius: 18px; margin-bottom: 15px; overflow: hidden;
-            img { width: 100%; height: 100%; object-fit: cover; }
-        }
-        .info h3 { font-size: 18px; color: #333; margin-bottom: 10px; }
-        .match { font-size: 12px; color: #FF7043; background: #FFF5F2; padding: 4px 10px; border-radius: 8px; font-weight: 700; }
-    `,
-    // 💡 상세 조리 과정(본 레시피 창) 스타일
+    
+    // ▼▼▼ 수정된 부분: 레시피 상세 모달 스타일 ▼▼▼
     detailOverlay: css`
         position: fixed; top: 0; left: 0; width: 100%; height: 100%;
-        background: rgba(0,0,0,0.8); display: flex; justify-content: center; align-items: center; z-index: 3000;
+        background: rgba(0,0,0,0.7); display: flex; justify-content: center; align-items: center; z-index: 3000;
+        backdrop-filter: blur(5px); /* 배경 블러 추가로 집중도 향상 */
     `,
     detailContent: css`
-        background: white; border-radius: 35px; width: 95%; max-width: 550px; height: 90vh;
-        padding: 40px; overflow-y: auto; position: relative;
-        .back-btn { background: none; border: none; color: #FF7043; font-weight: 800; cursor: pointer; margin-bottom: 20px; }
-        .step-item { margin-bottom: 45px; }
-        .step-num { font-size: 14px; font-weight: 900; color: #FF7043; margin-bottom: 12px; }
-        .step-img { width: 100%; border-radius: 20px; overflow: hidden; margin-bottom: 15px; 
-            img { width: 100%; display: block; }
+        background: white; 
+        border-radius: 30px; 
+        width: 95%; 
+        max-width: 720px; /* 550px -> 720px (황금 비율/가독성 최적화) */
+        height: 85vh; /* 90vh -> 85vh (위아래 여백 확보) */
+        padding: 40px; 
+        overflow-y: auto; 
+        position: relative;
+        box-shadow: 0 10px 40px rgba(0,0,0,0.2);
+
+        /* 스크롤바 숨기기 (선택사항 - 깔끔함을 원하시면 유지) */
+        &::-webkit-scrollbar { display: none; }
+        -ms-overflow-style: none;
+        scrollbar-width: none;
+
+        .back-btn { 
+            background: none; border: none; color: #FF7043; 
+            font-weight: 800; cursor: pointer; margin-bottom: 25px; font-size: 14px;
+            transition: 0.2s;
+            &:hover { transform: translateX(-5px); }
         }
-        .step-desc { font-size: 16px; line-height: 1.7; color: #444; word-break: keep-all; }
     `
 };

--- a/Team_LJCO_front/src/pages/Recipe/Recipe.jsx
+++ b/Team_LJCO_front/src/pages/Recipe/Recipe.jsx
@@ -1,14 +1,13 @@
 /** @jsxImportSource @emotion/react */
-import { useState, useEffect, useRef, useCallback } from "react";
+import { useState, useEffect } from "react";
 import axios from "axios";
-import { Global, keyframes } from "@emotion/react"; 
+import { Global } from "@emotion/react"; 
 import { fontImport, s as commonS } from "../Home/styles"; 
 import { s as recipeS } from "./styles"; 
 import RecipeSearchModal from "../../components/recipeModal/RecipeSearchModal";
-import { useNavigate, useLocation } from "react-router-dom"; // 💡 useLocation 추가
+import { useNavigate, useLocation } from "react-router-dom"; 
 import Pagination from "../../components/common/Pagination";
 import RecipeIngredientMark from "./RacipeIngredientMark";
-
 
 function Recipe() {
     const navigate = useNavigate();
@@ -21,83 +20,71 @@ function Recipe() {
     const [recipes, setRecipes] = useState([]);
     const [loading, setLoading] = useState(false);
 
-
-
     const [recipeSearchTerm, setRecipeSearchTerm] = useState("");
     const [isRecipeModalOpen, setIsRecipeModalOpen] = useState(false);
     const [selectedRecipe, setSelectedRecipe] = useState(null);
-    
 
-
-
-useEffect(() => {
-    const urlParams = new URLSearchParams(location.search);
-    const urlPage = Number(urlParams.get("page") ?? 1);
-
-
-    
-    const urlKeyword = urlParams.get("keyword");
-    const urlSort = urlParams.get("sort") ?? "VIEW_DESC";
-    setSort(urlSort);
-    setPage(urlPage);
-    
-    const fetchRecipes = async () => {
-        setLoading(true);
-        const token = localStorage.getItem("accessToken");
+    useEffect(() => {
+        const urlParams = new URLSearchParams(location.search);
+        const urlPage = Number(urlParams.get("page") ?? 1);
+        const urlKeyword = urlParams.get("keyword");
+        const urlSort = urlParams.get("sort") ?? "VIEW_DESC";
+        setSort(urlSort);
+        setPage(urlPage);
         
-        // 유저 없을시 32번 유저로 로그인(비로그인 기능 만들어야함)
-        const currentUserId = localStorage.getItem("userId") || 32;
+        const fetchRecipes = async () => {
+            setLoading(true);
+            const token = localStorage.getItem("accessToken");
+            const currentUserId = localStorage.getItem("userId") || 32;
 
-        try {
-            const url = `http://localhost:8080/api/recipes`;
-
-            const res = await axios.get(url, {
-                params: { 
-                    page: urlPage, 
-                    userId: currentUserId, 
-                    keyword: urlKeyword || undefined,
-                    sort: urlSort,
-                },
-                headers: { Authorization: `Bearer ${token}` }
-            });
-            const data = res.data;
+            try {
+                const url = `http://localhost:8080/api/recipes`;
+                const res = await axios.get(url, {
+                    params: { 
+                        page: urlPage, 
+                        userId: currentUserId, 
+                        keyword: urlKeyword || undefined,
+                        sort: urlSort,
+                    },
+                    headers: { Authorization: `Bearer ${token}` }
+                });
+                const data = res.data;
                 setRecipes(Array.isArray(data.recipes) ? data.recipes : []);
                 setTotalPages(typeof data.totalPages === "number" ? data.totalPages : 0);
 
+            } catch (err) {
+                console.error("데이터 로딩 실패:", err);
+            } finally {
+                setLoading(false);
+            }
+        };
 
-        } catch (err) {
-            console.error("데이터 로딩 실패:", err);
-        } finally {
-            setLoading(false);
-        }
-    };
+        fetchRecipes();
+    }, [location.search]);
 
-    fetchRecipes();
-}, [location.search]);
-
-const handleSort = (sort) => {
-    const params = new URLSearchParams(location.search);
-
-    params.set("sort", sort);
-    params.set("page", "1");
-    setPage(1);
-    navigate(`/recipe?${params.toString()}`);
-}
+    const handleSort = (sort) => {
+        const params = new URLSearchParams(location.search);
+        params.set("sort", sort);
+        params.set("page", "1");
+        setPage(1);
+        navigate(`/recipe?${params.toString()}`);
+    }
 
     const handleRecipeSearch = () => {
-    if (!recipeSearchTerm.trim()) return;
-    const params = new URLSearchParams(location.search);
-    params.set("keyword",recipeSearchTerm);
-    params.set("sort", sort);
-    params.set("page", "1");
-
-    navigate(`/recipe?${params.toString()}`);
+        if (!recipeSearchTerm.trim()) return;
+        const params = new URLSearchParams(location.search);
+        params.set("keyword", recipeSearchTerm);
+        params.set("sort", sort);
+        params.set("page", "1");
+        navigate(`/recipe?${params.toString()}`);
     };
+
     return (
         <>
             <Global styles={fontImport} /> 
             <div css={commonS.wrapper}>
                 <div css={commonS.container}>
+                    {/* 1. 헤더 카드 (검색창, 로고, 메뉴) */}
                     <div css={commonS.headerCard}>
                         <div css={commonS.logo} onClick={() => navigate("/home")}>
                             <div className="logo-box">🧊</div> 냉장고 파먹기
@@ -112,17 +99,9 @@ const handleSort = (sort) => {
                                 onKeyDown={(e) => e.key === 'Enter' && handleRecipeSearch()}
                             />
                         </div>
-                        <div>
-                            <button onClick={() => handleSort("VIEW_DESC")}>
-                                조회수순
-                            </button>
-                            <button onClick={() => handleSort("LEVEL_DESC")}>
-                                난이도순
-                            </button>
-                            <button onClick={() => handleSort("MATCHRATE_DESC")}>
-                                매치율순
-                            </button>
-                        </div>
+                        
+                        {/* 기존 정렬 버튼 있던 곳 -> 삭제됨 */}
+                        
                         <div css={commonS.navGroup}>
                             <button css={commonS.pillBtn(false)} onClick={() => navigate("/home")}>🏠 식재료</button>
                             <button css={commonS.pillBtn(true)} onClick={() => navigate("/recipe")}>📖 레시피</button>
@@ -132,85 +111,95 @@ const handleSort = (sort) => {
                         </div>
                     </div>
 
+                    {/* 2. 메인 배너 */}
                     <div css={recipeS.banner}>
                         <div className="tag">🔥 오늘의 추천</div>
                         <h2>냉장고 재료로 만드는<br/>특별한 요리</h2>
                     </div>
 
+                    {/* 3. 정렬 버튼 (배너 아래로 이동됨) */}
+                    <div css={recipeS.controlBar}>
+                        <button css={recipeS.sortBtn(sort === "VIEW_DESC")} onClick={() => handleSort("VIEW_DESC")}>
+                            👁️ 조회수순
+                        </button>
+                        <button css={recipeS.sortBtn(sort === "LEVEL_DESC")} onClick={() => handleSort("LEVEL_DESC")}>
+                            🔥 난이도순
+                        </button>
+                        <button css={recipeS.sortBtn(sort === "MATCHRATE_DESC")} onClick={() => handleSort("MATCHRATE_DESC")}>
+                            🛒 매치율순
+                        </button>
+                    </div>
+
+                    {/* 4. 레시피 그리드 */}
                     <div css={recipeS.recipeGrid}>
-                        {recipes.map((recipe, index) => {
-                            const isLast = recipes.length === index + 1;
-                            return (
-                                <div 
-                                   
-                                    key={`${recipe.rcpId}-${index}`} // 💡 중복 키 에러 방지를 위해 index 조합
-                                    css={recipeS.recipeCard}
-                                    onClick={() => {
-                                        // 💡 카드를 클릭했을 때만 모달이 뜨게 합니다.
-                                        setSelectedRecipe(recipe); 
-                                        setIsRecipeModalOpen(true);
-                                    }}
-                                    style={{ cursor: 'pointer' }} // 클릭 가능하다는 시각적 표시
-                                >
-                                    <RecipeCardContent recipe={recipe} />
-                                </div>
-                            );
-                        })}
+                        {recipes.map((recipe, index) => (
+                            <div 
+                                key={`${recipe.rcpId}-${index}`} 
+                                css={recipeS.recipeCard}
+                                onClick={() => {
+                                    setSelectedRecipe(recipe); 
+                                    setIsRecipeModalOpen(true);
+                                }}
+                                style={{ cursor: 'pointer' }} 
+                            >
+                                <RecipeCardContent recipe={recipe} />
+                            </div>
+                        ))}
                         {loading && <div style={{gridColumn: '1/-1', textAlign: 'center', padding: '20px'}}>
                         추가 레시피 로딩 중...</div>}
                     </div>
+
+                    {/* 5. 페이지네이션 */}
                     <Pagination
-                    page={page}
-                    totalPages={totalPages}
-                    onChange={(p) => {
-                        const params = new URLSearchParams(location.search);
-                        params.set("page", String(p));
-                        navigate(`/recipe?${params.toString()}`);
-                    }}
+                        page={page}
+                        totalPages={totalPages}
+                        onChange={(p) => {
+                            const params = new URLSearchParams(location.search);
+                            params.set("page", String(p));
+                            navigate(`/recipe?${params.toString()}`);
+                        }}
                     />
                 </div>
 
-                {isRecipeModalOpen && <RecipeSearchModal 
-        recipe={selectedRecipe} 
-        onClose={() => {
-            setIsRecipeModalOpen(false);
-            setSelectedRecipe(null);
-        }} 
-    />}
+                {/* 6. 모달 */}
+                {isRecipeModalOpen && (
+                    <RecipeSearchModal 
+                        recipe={selectedRecipe} 
+                        onClose={() => {
+                            setIsRecipeModalOpen(false);
+                            setSelectedRecipe(null);
+                        }} 
+                    />
+                )}
             </div>
         </>
     );
 }
 
-
-
 function RecipeCardContent({ recipe }) {
-
     const matchRate = Number(recipe.matchRate ?? 0);
 
     const getMatchRateText = (rate) => {
         if(rate <= 0) return '재료를 구매하셔야 해요!';
-        if(rate <50) return '조금만 더 있으면 돼요';
+        if(rate < 50) return '조금만 더 있으면 돼요';
         if(rate < 70) return '거의 만들 수 있어요';
         return '지금 바로 도전 가능!';
     };
 
+    const getLevelText = (level) => {
+        if (level === 1) return '쉬움';
+        if (level === 2) return '보통';
+        if (level === 3) return '어려움';
+        return '미정';
+    };
+
     return (
-        <div style={{ borderRadius: '30px', overflow: 'hidden' }}>
-            
-            <div className="thumb" style={{ 
-                position: 'relative', 
-                width: '100%', 
-                height: '240px', 
-                margin: 0, 
-                borderRadius: '0' 
-            }}>
+        <div style={{ borderRadius: '30px', overflow: 'hidden', height: '100%' }}>
+            <div className="thumb">
                 <img 
                     src={recipe.rcpImgUrl} 
                     alt={recipe.rcpName} 
-                    style={{ width: '100%', height: '100%', objectFit: 'cover' }} 
                 />
-                
                 
                 <div style={{ 
                     position: 'absolute', 
@@ -218,7 +207,7 @@ function RecipeCardContent({ recipe }) {
                     left: '15px', 
                     right: '15px', 
                     display: 'flex', 
-                    justifyContent: 'space-between',
+                    justifyContent: 'space-between', 
                     zIndex: 10
                 }}>
                     <span style={{ 
@@ -232,37 +221,58 @@ function RecipeCardContent({ recipe }) {
                     }}>
                         {getMatchRateText(matchRate)}{'\u00A0\u00A0'}{matchRate}%
                     </span>
-                    <span style={{ 
-                        background: 'rgba(255, 112, 67, 0.9)', 
-                        color: 'white', 
-                        padding: '6px 14px', 
-                        borderRadius: '12px', 
-                        fontSize: '12px', 
-                        fontWeight: '800',
-                        boxShadow: '0 4px 10px rgba(0,0,0,0.1)'
-                    }}>
-                         {recipe.level === 1 ? '쉬움' : recipe.level === 2 ? '보통' :  recipe.level === 2 ? '중급' : '어려움'}
-                    </span>
                 </div>
             </div>
 
-            <div style={{ padding: '20px 5px' }}>
-                <h3 style={{ fontSize: '20px', fontWeight: '800', marginBottom: '8px' }}>{recipe.rcpName}</h3>
-                <div className="meta" style={{ display: 'flex', gap: '15px', fontSize: '12px', color: '#FF7043', fontWeight: '700', marginBottom: '15px' }}>
-                    <span>👁️ {recipe.rcpViewCount?.toLocaleString()}</span>
-                    <span>⏱️ 15분</span>
-                    <span>👥 2인분</span>
+            <div className="content">
+                <h3 style={{ fontSize: '20px', fontWeight: '800', marginBottom: '8px' }}>
+                    {recipe.rcpName}
+                </h3>
+                
+                <div style={{ 
+                    display: 'flex', 
+                    alignItems: 'center', 
+                    gap: '15px', 
+                    marginBottom: '15px' 
+                }}>
+                    <span style={{ 
+                        display: 'flex', 
+                        alignItems: 'center', 
+                        gap: '4px',
+                        color: '#FF7043', 
+                        fontSize: '15px', 
+                        fontWeight: '800' 
+                    }}>
+                        🔥 {getLevelText(recipe.level)}
+                    </span>
+
+                    <span style={{ 
+                        display: 'flex', 
+                        alignItems: 'center', 
+                        gap: '4px',
+                        color: '#FF7043', 
+                        fontSize: '15px', 
+                        fontWeight: '700' 
+                    }}>
+                        👁 {recipe.rcpViewCount?.toLocaleString() || 0}
+                    </span>
                 </div>
 
-                {/* 3. 재료 리스트 */}
+                <div style={{ 
+                    width: '100%', 
+                    height: '1px', 
+                    background: '#E0E0E0', 
+                    margin: '15px 0' 
+                }}></div>
+
                 <div className="ingredients">
                     <div className="label" style={{ fontSize: '11px', color: '#999', marginBottom: '8px' }}>
-                        필요한 재료</div>
+                        필요한 재료
+                    </div>
 
                     <div style={{ display: 'flex', flexWrap: 'wrap', gap: '6px' }}>
                         {recipe.ingredients?.map((ingredients, idx) => (
-                            <RecipeIngredientMark key={idx} ingredients={ingredients} 
-                            />
+                            <RecipeIngredientMark key={idx} ingredients={ingredients} />
                         ))}
                     </div>
                 </div>

--- a/Team_LJCO_front/src/pages/Recipe/styles.js
+++ b/Team_LJCO_front/src/pages/Recipe/styles.js
@@ -2,6 +2,30 @@
 import { css } from "@emotion/react";
 
 export const s = {
+
+    controlBar: css`
+        display: flex;
+        justify-content: flex-end;
+        align-items: center;
+        gap: 8px;
+        margin-bottom: 1px; /* ⚡ 수정됨: 버튼과 그리드 사이 간격 좁힘 */
+    `,
+    sortBtn: (isActive) => css`
+        padding: 8px 16px;
+        border-radius: 20px;
+        border: 1px solid ${isActive ? "#FF7043" : "#E0E0E0"};
+        background-color: ${isActive ? "#FF7043" : "#FFFFFF"};
+        color: ${isActive ? "#FFFFFF" : "#888888"};
+        font-size: 13px;
+        font-weight: 700;
+        cursor: pointer;
+        transition: all 0.2s ease;
+
+        &:hover {
+            background-color: ${isActive ? "#FF7043" : "#F5F5F5"};
+            transform: translateY(-2px);
+        }
+    `,
     // 레시피 페이지 전용 배너
     banner: css`
         background: #FF7043;
@@ -10,7 +34,7 @@ export const s = {
         color: #FFFFFF;
         position: relative;
         overflow: hidden;
-        margin-bottom: 20px;
+        margin-bottom: 1px; /* ⚡ 수정됨: 배너와 버튼 사이 간격 좁힘 */
 
         .tag {
             background: rgba(255, 255, 255, 0.2);
@@ -36,20 +60,30 @@ export const s = {
         margin-bottom: 100px;
     `,
     recipeCard: css`
-        background: #FFFFFF;
-        border-radius: 30px;
-        padding: 25px;
-        position: relative;
-        box-shadow: 0 4px 15px rgba(0,0,0,0.03);
-        transition: 0.3s;
-        &:hover { transform: translateY(-5px); box-shadow: 0 10px 30px rgba(0,0,0,0.08); }
+    background: #FFFFFF;
+    border-radius: 30px;
+    padding: 0; /* 1. 패딩 제거 (이미지 꽉 채우기 위함) */
+    position: relative;
+    box-shadow: 0 4px 15px rgba(0,0,0,0.03);
+    transition: 0.3s;
+    overflow: hidden; /* 이미지가 둥근 모서리를 넘치지 않게 자름 */
+    
+    &:hover { transform: translateY(-5px); box-shadow: 0 10px 30px rgba(0,0,0,0.08); }
 
-        .thumb {
-            width: 100%; height: 200px;
-            background: #F5F5F5; border-radius: 20px;
-            margin-bottom: 20px; overflow: hidden;
-            img { width: 100%; height: 100%; object-fit: cover; }
-        }
+    .thumb {
+        width: 100%; 
+        height: 240px;
+        background: #F5F5F5; 
+        margin: 0; /* 마진 제거 */
+        
+        img { width: 100%; height: 100%; object-fit: cover; }
+    }
+
+    .content {
+        padding: 25px; 
+    }
+
+    h3 { font-size: 20px; font-weight: 800; margin: 0 0 10px 0; }
         .stats {
             display: flex; gap: 8px; margin-bottom: 15px;
             span { 
@@ -66,9 +100,8 @@ export const s = {
             margin-bottom: 20px;
         }
         .ingredients {
-            display: flex; flex-wrap: wrap; gap: 6px;
-            .label { font-size: 11px; color: #999; width: 100%; margin-bottom: 4px; }
-            .ing { background: #F8F5F2; padding: 4px 10px; border-radius: 8px; font-size: 11px; color: #666; }
-        }
-    `
+        display: flex; flex-wrap: wrap; gap: 6px;
+        .label { font-size: 11px; color: #999; width: 100%; margin-bottom: 4px; }
+    }
+`
 };


### PR DESCRIPTION

- 카드 내 패딩을 제거하고 이미지를 상단에 꽉 채워 시각적 몰입감 향상
    불필요한 목데이터(시간, 인분)를 삭제하고 실제 데이터(조회수, 난이도) 중심으로 재배치
    정보 간 구분선 추가 및 메타 정보 디자인 고도화
    레시피 상세 모달 개선


- 사용자 가독성을 고려한 황금 비율 크기(720px / 85vh)로 확장
      상단 영역 레이아웃 변경: 좌측(난이도, 조회수)과 우측(매치율 메시지) 정보 분리 배치
      내부 불필요 섹션 제거를 통한 레이아웃 간소화
      정렬 버튼 위치 및 디자인 변경


- 정렬 버튼군을 헤더에서 레시피 그리드 우측 상단으로 이동하여 직관적 동선 확보
    둥근 칩(Chip) 형태의 디자인과 주황색 포인트 컬러 적용
    

- 페이지네이션 스타일링
    브랜드 컬러(주황색)와 원형 디자인을 적용하여 UI 일관성 강화
    

- 전체 레이아웃 미세 조정
    배너, 버튼바, 그리드 사이의 여백을 축소하여 화면의 밀도와 긴장감 조절