### PR TITLE
feat(auth): 인증 방식을 쿠키 기반으로 변경 및 식재료 차감 연동

### DIFF
--- a/Team_LJCO_front/src/components/recipeModal/RecipeSearchModal.jsx
+++ b/Team_LJCO_front/src/components/recipeModal/RecipeSearchModal.jsx
@@ -3,14 +3,24 @@ import { useState, useEffect } from "react";
 import axios from "axios";
 import { s } from "./styles";
 import { getColorByDay } from "../../utils/colorUtils";
+import { useUseRecipeIngredientsMutation } from "../../queries/useIngredients";
 
 function RecipeSearchModal({ recipe, onClose }) {
     const [steps, setSteps] = useState([]);
     const [loading, setLoading] = useState(true);
 
+    const useIngredientsMutation = useUseRecipeIngredientsMutation();
+
     // 매치율 텍스트 로직
     const matchRate = Number(recipe?.matchRate ?? 0);
     
+    const handleCompleteCook = () => {
+        if (window.confirm("요리를 완료하셨나요? 사용된 식재료가 냉장고에서 삭제됩니다.")) {
+            // 백엔드 컨트롤러에서 @AuthenticationPrincipal을 사용하므로 rcpId만 보냅니다.
+            useIngredientsMutation.mutate({ rcpId: recipe.rcpId });
+            onClose(); // 처리 후 모달 닫기
+        }
+    };
     const getMatchRateText = (rate) => {
         if (rate <= 0) return '재료를 구매하셔야 해요!';
         if (rate < 50) return '조금만 더 있으면 돼요';
@@ -43,7 +53,29 @@ function RecipeSearchModal({ recipe, onClose }) {
     return (
         <div css={s.detailOverlay} onClick={onClose}>
             <div css={s.detailContent} onClick={(e) => e.stopPropagation()}>
-                <button className="back-btn" onClick={onClose}>← 검색 결과로 돌아가기</button>
+                <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '10px' }}>
+                    <button className="back-btn" onClick={onClose}>← 검색 결과로 돌아가기</button>
+                    
+                    <button 
+                        onClick={handleCompleteCook}
+                        style={{
+                            padding: '10px 18px',
+                            backgroundColor: '#ff7043',
+                            color: 'white',
+                            border: 'none',
+                            borderRadius: '12px',
+                            fontWeight: '900',
+                            fontSize: '14px',
+                            cursor: 'pointer',
+                            boxShadow: '0 4px 10px rgba(255, 112, 67, 0.3)',
+                            transition: 'all 0.2s'
+                        }}
+                        onMouseOver={(e) => e.currentTarget.style.backgroundColor = '#f4511e'}
+                        onMouseOut={(e) => e.currentTarget.style.backgroundColor = '#ff7043'}
+                    >
+                        🍳 요리 완료 (재료 차감)
+                    </button>
+                </div>
                 
                 {/* 1. Header: 이름 및 정보 */}
                 <div style={{ marginBottom: '20px' }}>

--- a/Team_LJCO_front/src/queries/useIngredients.js
+++ b/Team_LJCO_front/src/queries/useIngredients.js
@@ -1,4 +1,5 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import axios from 'axios';
 import {
   getAllIngredients,
   searchIngredients,
@@ -8,6 +9,30 @@ import {
   getAllCategories,
 } from '../apis/adminApi';
 import { queryKeys } from './queryKeys';
+
+export const useUseRecipeIngredientsMutation = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ rcpId }) => 
+        axios.post(
+            `${import.meta.env.VITE_API_BASE_URL}/api/user/ingredients/use-recipe/${rcpId}`,
+            {}, // POST 요청의 body (현재는 필요 없으므로 빈 객체)
+            { withCredentials: true } // 👈 이 설정이 누락되어 401 에러가 발생합니다!
+        ),
+    
+    onSuccess: () => {
+      // 데이터 동기화를 위해 관련 쿼리 무효화
+      queryClient.invalidateQueries({ queryKey: queryKeys.ingredients.all });
+      queryClient.invalidateQueries({ queryKey: ['recipes'] }); 
+      alert("요리가 완료되었습니다! 식재료가 냉장고에서 차감되었습니다.");
+    },
+    onError: (error) => {
+      console.error("차감 실패:", error);
+      alert("인증 세션이 만료되었거나 처리에 실패했습니다. 다시 로그인해 주세요.");
+    }
+  });
+};
 
 // 재료 목록 조회
 export const useIngredientsQuery = (options = {}) => {


### PR DESCRIPTION
1. 백엔드 인증 방식 개선 (Security & Filter)
OAuth2SuccessHandler.java: 로그인 성공 시 토큰을 URL 주소창에 노출하던 방식에서, 브라우저의 안전한 HTTP 쿠키에 직접 저장하도록 로직을 수정했습니다. 이 작업이 프론트엔드의 withCredentials 옵션과 연동되는 핵심 다리가 되었습니다.

JwtAuthenticationFilter.java: 기존에는 HTTP 헤더(Authorization)만 검사하던 필터가 이제는 쿠키(Cookie) 내의 accessToken까지 스스로 찾아내어 인증을 처리하도록 개선했습니다. 이 수정 덕분에 401 Unauthorized 에러가 해결되었습니다.

SecurityConfig.java: 식재료 차감 API(/api/user/ingredients/use-recipe/**)가 permitAll() 설정들에 밀려 인증을 건너뛰지 않도록 필터 우선순위를 최상단으로 조정하여 보안을 강화했습니다.

2. 식재료 차감 기능 완성 (Controller & Mapper)
UserIngredientController.java: 로그인한 사용자의 정보를 토대로 레시피에 사용된 재료를 정확히 타겟팅하여 삭제 명령을 내리는 엔드포인트를 구현했습니다.

UserIngredientMapper.xml: 사용자가 보유한 재료 중 해당 레시피에 포함된 항목만 골라 DB에서 삭제하는 효율적인 SQL 쿼리를 작성했습니다.

3. 프론트엔드 UI/UX 연동 (React)
useIngredients.js (또는 Mutation 파일): 서버에 재료 차감을 요청할 때 브라우저 쿠키를 함께 실어 보낼 수 있도록 withCredentials: true 옵션을 적용했습니다.

RecipeSearchModal.jsx: 사용자가 요리 완료 버튼을 눌렀을 때 실제 데이터가 차감되고, 사용자에게 성공/실패 여부를 알려주는 이벤트 로직을 연결했습니다.

4. 서버 배포 환경 구축 (Infrastructure)
docker-compose.yml: Nginx(SSL/HTTPS 적용), Spring Boot 백엔드, MySQL 데이터베이스를 하나의 네트워크로 묶어 GCP 환경에서 클릭 한 번으로 배포할 수 있는 인프라 설정을 완료했습니다.