### PR TITLE
feat(ui): 식재료 D-Day 배지 디자인 고도화 및 헤더 이모티콘 교체

### DIFF
--- a/Team_LJCO_front/src/components/recipe/RecipeCardContent.jsx
+++ b/Team_LJCO_front/src/components/recipe/RecipeCardContent.jsx
@@ -6,11 +6,33 @@ export default function RecipeCardContent({ recipe }) {
   const matchRate = Number(recipe.matchRate ?? 100); // ✅ cookable은 100으로 취급 가능
 
   const getMatchRateStyle = (rate) => {
-    if (rate === 100) return { text: "지금 바로 도전 가능!", color: "#28a745" };
-    if (rate >= 80) return { text: "거의 만들 수 있어요", color: "#FF9800" };
-    if (rate >= 50) return { text: "조금만 더 있으면 돼요", color: "#FF7043" };
-    return { text: "재료를 구매하셔야 해요!", color: "#999999" };
+  if (rate === 100) {
+    return { 
+      text: "지금 바로 도전 가능!", 
+      bg: "#C8E6C9", // 연한 초록 (불투명)
+      color: "#1B5E20" // 더 진한 초록 글씨
+    };
+  }
+  if (rate >= 80) {
+    return { 
+      text: "거의 만들 수 있어요", 
+      bg: "#FFF9C4", // 연한 노랑 (불투명)
+      color: "#F57F17" // 더 진한 금색 글씨
+    };
+  }
+  if (rate >= 50) {
+    return { 
+      text: "조금만 더 있으면 돼요", 
+      bg: "#FFE0B2", // 연한 주황 (불투명)
+      color: "#E65100" // 더 진한 주황 글씨
+    };
+  }
+  return { 
+    text: "재료를 구매하셔야 해요!", 
+    bg: "#EEEEEE", // 연한 회색 (불투명)
+    color: "#757575" // 진한 회색 글씨
   };
+};
 
   const matchStyle = getMatchRateStyle(matchRate);
 
@@ -31,16 +53,16 @@ export default function RecipeCardContent({ recipe }) {
           }}
         >
           <span
-            style={{
-              background: matchStyle.color,
-              color: "white",
-              padding: "6px 16px",
-              borderRadius: "20px",
-              fontSize: "12px",
-              fontWeight: "800",
-              boxShadow: "0 4px 10px rgba(0,0,0,0.2)",
-            }}
-          >
+  style={{
+    background: matchStyle.bg,    // ✅ 정의한 연한 파스텔 배경 사용
+    color: matchStyle.color,      // ✅ 진한 포인트 컬러를 글자색으로 사용
+    padding: "6px 16px",
+    borderRadius: "20px",
+    fontSize: "12px",
+    fontWeight: "700",            // 파스텔톤에선 두꺼워야 잘 보입니다
+    boxShadow: "0 2px 10px rgba(0,0,0,0.05)",
+  }}
+>
             {matchStyle.text}{"\u00A0\u00A0"}
             {matchRate}%
           </span>
@@ -76,13 +98,15 @@ export default function RecipeCardContent({ recipe }) {
             필요한 재료
           </div>
 
-          <div style={{ display: "flex", flexWrap: "wrap", gap: "6px" }}>
+         <div style={{ display: "flex", flexWrap: "wrap", gap: "6px" }}>
             {(recipe.ingredients ?? recipe.userIngredients ?? []).map((ing, idx) => (
               <RecipeIngredientMark
                 key={idx}
                 ingredients={{
                   ingName: ing.ingName ?? ing,
-                  matchedColor: "G",
+                  // ✅ 수정 포인트: 고정된 "G" 대신, 데이터가 가진 실제 matchedColor를 사용합니다.
+                  // 데이터가 없으면 기본값인 "N"(미보유)을 사용합니다.
+                  matchedColor: ing.matchedColor || "N",
                 }}
               />
             ))}

--- a/Team_LJCO_front/src/components/recipeModal/RecipeSearchModal.jsx
+++ b/Team_LJCO_front/src/components/recipeModal/RecipeSearchModal.jsx
@@ -120,30 +120,29 @@ function RecipeSearchModal({ recipe, onClose }) {
                     
                       <div style={{ display: 'flex', flexWrap: 'wrap', gap: '8px' }}>
     {recipe.ingredients?.map((ing, idx) => {
-        // ✅ 콘솔 확인 결과: matchedColor 필드가 "G"이면 보유(초록불), "N"이면 미보유입니다.
-        const isMatched = ing.matchedColor === "G";
-        
-        // ✅ 보유 중("G")일 때만 초록색을 적용하고, 아니면 회색/검정색으로 표시합니다.
-        // 만약 D-Day에 따른 다른 색상(Y, O, R 등)도 있다면 추가 대응이 가능합니다.
-        const bgColor = isMatched ? "#b9f6ca" : "#333333"; 
-        const textColor = isMatched ? "#000000" : "#999999";
+        // RecipeSearchModal.jsx 내 변수 설정 부분
+const isMatched = ing.matchedColor === "G";
 
-        return (
-            <span key={idx} style={{
-                backgroundColor: bgColor,
-                color: textColor,
-                padding: '8px 16px', 
-                borderRadius: '12px', 
-                fontSize: '14px', 
-                fontWeight: '600',
-                // 보유하지 않은 재료는 테두리를 주어 구분
-                border: isMatched ? 'none' : '1px solid #444',
-                boxShadow: isMatched ? '0 2px 5px rgba(0,0,0,0.1)' : 'none',
-                transition: 'all 0.2s ease'
-            }}>
-                {ing.ingName} {ing.rcpIngAmt && `(${ing.rcpIngAmt})`}
-            </span>
-        );
+// 보유 시 농도를 높인 배경색 사용
+const bgColor = isMatched ? "#C8E6C9" : "#F5F5F5"; 
+const textColor = isMatched ? "#1B5E20" : "#757575";
+const borderColor = isMatched ? "#A5D6A7" : "#E0E0E0"; // 테두리도 조금 더 진하게
+
+return (
+    <span key={idx} style={{
+        backgroundColor: bgColor,
+        color: textColor,
+        padding: '8px 16px', 
+        borderRadius: '12px', 
+        fontSize: '14px', 
+        fontWeight: '700',
+        border: `1.5px solid ${borderColor}`, // 테두리를 연하게 주어 카드와 일관성 유지
+        boxShadow: isMatched ? '0 2px 8px rgba(0, 200, 83, 0.05)' : 'none',
+        transition: 'all 0.2s ease'
+    }}>
+        {ing.ingName} {ing.rcpIngAmt && `(${ing.rcpIngAmt})`}
+    </span>
+);
     })}
 </div>
                 </div>

--- a/Team_LJCO_front/src/pages/Home/Home.jsx
+++ b/Team_LJCO_front/src/pages/Home/Home.jsx
@@ -186,7 +186,17 @@ function Home() {
                   return (
                     <div key={item.userIngId} css={s.foodCard} style={{ backgroundColor: dateInfo.isTrash ? "#F5F5F5" : "#FFFFFF" }}>
                       <button className="delete-target" css={s.deleteBtn} onClick={(e) => handleDelete(item.userIngId, e)}>×</button>
-                      <span className="badge" style={{ backgroundColor: dateInfo.color }}>{dateInfo.text}</span>
+                      <span 
+  className="badge" 
+  style={{ 
+    backgroundColor: dateInfo.bgColor, // ✅ 연한 파스텔 배경
+    color: dateInfo.textColor,         // ✅ 진한 포인트 글자색
+    border: `1px solid ${dateInfo.textColor}22`, // 미세한 테두리로 선명도 업
+    fontWeight: "900",                 // 파스텔 톤에서 가독성 확보
+  }}
+>
+  {dateInfo.text}
+</span>
                       <img 
                         src={`${import.meta.env.VITE_API_BASE_URL}/images/${item.ingredient?.ingImgUrl}`} 
                         alt="" 

--- a/Team_LJCO_front/src/pages/Recipe/RacipeIngredientMark.jsx
+++ b/Team_LJCO_front/src/pages/Recipe/RacipeIngredientMark.jsx
@@ -1,24 +1,29 @@
 export default function RecipeIngredientMark({ingredients}) {
     const whatColor = ingredients.matchedColor;
 
+    // ✅ 모달의 파스텔톤 시스템과 100% 일치시킴
     const ingColor = {
-        G : { background: "#B9F6CA", color: "#000" },
-        R : { background: "#FFCDD2", color: "#000" },
-        N : { background: "#F0F0F0", color: "#999" },
+        G : { background: "#E8F5E9", color: "#2E7D32", border: "#C8E6C9" }, // 보유 (연초록)
+        R : { background: "#FFEBEE", color: "#C62828", border: "#FFCDD2" }, // 유통기한 임박/위험 (연빨강)
+        N : { background: "#FAFAFA", color: "#BDBDBD", border: "#EEEEEE" }, // 미보유 (연회색)
     };
 
     const style = ingColor[whatColor] ?? ingColor.N;
     
-return(
-    <span style = {{
-        ...style,
-        padding: "4px 10px",
-        borderRadius: "8px",
-        fontSize: "11px",
-        display: "inline-block",
-
-    }}>
-        {ingredients.ingName}
-</span>
-);
+    return (
+        <span style={{
+            ...style,
+            backgroundColor: style.background,
+            color: style.color,
+            border: `1px solid ${style.border}`, // 테두리 추가로 선명도 향상
+            padding: "4px 10px",
+            borderRadius: "8px",
+            fontSize: "11px",
+            fontWeight: "700", // 글자 가독성을 위해 두께 추가
+            display: "inline-block",
+            transition: "all 0.2s ease"
+        }}>
+            {ingredients.ingName}
+        </span>
+    );
 }

--- a/Team_LJCO_front/src/utils/date.js
+++ b/Team_LJCO_front/src/utils/date.js
@@ -1,26 +1,30 @@
 /**
- * 날짜 관련 유틸리티
- */
-
-/**
  * 날짜로부터 경과 일수 계산 및 상태 정보 반환
  * @param {string|Date} createDate - 생성 날짜
- * @returns {{text: string, color: string, opacity: number, isTrash: boolean}}
+ * @returns {{text: string, bgColor: string, textColor: string, opacity: number, isTrash: boolean}}
  */
 export const getDaysInfo = (createDate) => {
   if (!createDate) {
-    return { text: "D+0", color: "#34C759", opacity: 1.0, isTrash: false };
+    // 기본값 (파스텔 초록 테마)
+    return { text: "D+0", bgColor: "#E8F5E9", textColor: "#2E7D32", opacity: 1.0, isTrash: false };
   }
 
   const days = Math.floor(
     (new Date() - new Date(createDate)) / (1000 * 60 * 60 * 24)
   );
 
-  const getColor = (d) => {
-    if (d < 7) return "#34C759";   // 초록색 - 신선
-    if (d <= 14) return "#FFD60A"; // 노랑색 - 주의
-    if (d <= 29) return "#FF9F0A"; // 주황색 - 경고
-    return "#DBDBDB";              // 회색 - 폐기 필요
+  // ✅ 레시피 페이지의 파스텔톤 시스템과 100% 일치시킨 색상 로직
+  const getBadgeStyle = (d) => {
+    if (d < 7) {
+      return { bg: "#E8F5E9", text: "#2E7D32" }; // 연초록 (신선)
+    }
+    if (d <= 14) {
+      return { bg: "#FFFDE7", text: "#FBC02D" }; // 연노랑 (주의)
+    }
+    if (d <= 29) {
+      return { bg: "#FFF3E0", text: "#EF6C00" }; // 연주황 (경고)
+    }
+    return { bg: "#F5F5F5", text: "#9E9E9E" };   // 연회색 (폐기 필요)
   };
 
   const getOpacity = (d) => {
@@ -31,20 +35,13 @@ export const getDaysInfo = (createDate) => {
     return 1.0;
   };
 
+  const style = getBadgeStyle(days);
+
   return {
     text: `D+${days}`,
-    color: getColor(days),
+    bgColor: style.bg,    // ✅ Home.jsx에서 사용할 배경색
+    textColor: style.text, // ✅ Home.jsx에서 사용할 글자색
     opacity: getOpacity(days),
     isTrash: days >= 30,
   };
-};
-
-/**
- * 날짜 문자열 포맷팅 (YYYY-MM-DD)
- * @param {string} dateString - ISO 날짜 문자열
- * @returns {string} 포맷된 날짜
- */
-export const formatDate = (dateString) => {
-  if (!dateString) return "-";
-  return dateString.split("T")[0];
 };


### PR DESCRIPTION
- 메인 홈 식재료 배지를 레시피 페이지와 동일한 파스텔톤 시스템으로 변경
- 헤더 메뉴 아이콘 직관성 개선 (당근, 프라이팬, 문 조합)
- 레시피 카드 레이아웃 안정성 확보를 위한 스타일 수정